### PR TITLE
Fix non-ASCII digits in shared LAN address

### DIFF
--- a/lib/settingPage.dart
+++ b/lib/settingPage.dart
@@ -293,7 +293,7 @@ class _SettingPageState extends State<SettingPage> {
                   ip = await NetworkInfo().getWifiIP();
                 } catch (_) {}
                 if (!context.mounted) return;
-                final host = (ip == null || ip.isEmpty) ? "127.0.0.1" : ip;
+                final host = (ip == null || ip.isEmpty) ? "127.0.0.1" : _asciiDigits(ip);
                 final shareUrl = Uri.parse(Workflow.resolveWebUrl()).replace(host: host).toString();
                 FlutterClipboard.copy(shareUrl).then((value) {
                   if (!context.mounted) return;
@@ -416,6 +416,22 @@ class _SettingPageState extends State<SettingPage> {
         ],
       ),
     );
+  }
+
+  // Pre-API 31 network_info_plus formats the IP with the device's locale,
+  // so Arabic/Persian locales can return non-ASCII digits.
+  String _asciiDigits(String input) {
+    final buffer = StringBuffer();
+    for (final rune in input.runes) {
+      if (rune >= 0x0660 && rune <= 0x0669) {
+        buffer.write(rune - 0x0660); // Arabic-Indic
+      } else if (rune >= 0x06F0 && rune <= 0x06F9) {
+        buffer.write(rune - 0x06F0); // Extended Arabic-Indic (Persian)
+      } else {
+        buffer.writeCharCode(rune);
+      }
+    }
+    return buffer.toString();
   }
 
   //手动开启「自动选择启动后访问地址」时的提示


### PR DESCRIPTION
## Problem
On Android versions before API 31, `network_info_plus` formats the WiFi IP using `String.format("%d...")` without a fixed `Locale`. On devices set to an Arabic/Persian locale, this can render the IP using that locale's numbering system (e.g. Arabic-Indic digits) instead of ASCII digits. The "Copy Share Link" feature (Settings > LAN Access) then builds a URL from this value, producing an invalid host when pasted elsewhere.

## Fix
Normalize Arabic-Indic (U+0660-U+0669) and Extended Arabic-Indic/Persian (U+06F0-U+06F9) digits to ASCII before using the IP to build the share URL.

## Notes
Dart-only change, no new dependencies. Not build-tested (no Flutter SDK in the environment this was written in).